### PR TITLE
iOS / OS X compiling

### DIFF
--- a/attributed-markdown.pch
+++ b/attributed-markdown.pch
@@ -6,5 +6,6 @@
     #import <Foundation/Foundation.h>
     #include "TargetConditionals.h"
     #import <CoreText/CoreText.h>
-    #import <UIKit/UIKit.h>
+    #import "platform.h"
+
 #endif

--- a/markdown.xcodeproj/project.pbxproj
+++ b/markdown.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		F3DB478C15FFB8C800FC0AA0 /* markdown_lib.m in Sources */ = {isa = PBXBuildFile; fileRef = 6334F273130C8CEE000D1180 /* markdown_lib.m */; };
 		F3DB478D15FFB8C800FC0AA0 /* markdown_output.m in Sources */ = {isa = PBXBuildFile; fileRef = 6334F274130C8CEE000D1180 /* markdown_output.m */; };
 		F3DB479915FFBCB700FC0AA0 /* libattr-markdown-iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F3DB479415FFB8C800FC0AA0 /* libattr-markdown-iOS.a */; };
+		FA8982AB17E941A300CA487B /* platform.h in Headers */ = {isa = PBXBuildFile; fileRef = FA8982AA17E941A300CA487B /* platform.h */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXBuildRule section */
@@ -104,6 +105,7 @@
 		F3DB478515FFB7E200FC0AA0 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS6.0.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
 		F3DB478715FFB7EB00FC0AA0 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS6.0.sdk/System/Library/Frameworks/CoreGraphics.framework; sourceTree = DEVELOPER_DIR; };
 		F3DB479415FFB8C800FC0AA0 /* libattr-markdown-iOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libattr-markdown-iOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FA8982AA17E941A300CA487B /* platform.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = platform.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -195,6 +197,7 @@
 			children = (
 				6334F273130C8CEE000D1180 /* markdown_lib.m */,
 				6334F272130C8CEE000D1180 /* markdown_lib.h */,
+				FA8982AA17E941A300CA487B /* platform.h */,
 				6334F274130C8CEE000D1180 /* markdown_output.m */,
 				6334F275130C8CEE000D1180 /* markdown_parser.leg */,
 				6334F276130C8CEE000D1180 /* markdown_peg.h */,
@@ -256,6 +259,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				38EB00391672704F004A48F6 /* attributed-markdown.pch in Headers */,
+				FA8982AB17E941A300CA487B /* platform.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -636,6 +640,7 @@
 				HEADER_SEARCH_PATHS = "";
 				INSTALL_PATH = "";
 				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = NO;
 				PRIVATE_HEADERS_FOLDER_PATH = "";
 				PRODUCT_NAME = "attr-markdown-iOS";
 				PUBLIC_HEADERS_FOLDER_PATH = "";
@@ -657,6 +662,7 @@
 				HEADER_SEARCH_PATHS = "";
 				INSTALL_PATH = "";
 				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = NO;
 				PRIVATE_HEADERS_FOLDER_PATH = "";
 				PRODUCT_NAME = "attr-markdown-iOS";
 				PUBLIC_HEADERS_FOLDER_PATH = "";

--- a/markdown_output.m
+++ b/markdown_output.m
@@ -103,9 +103,9 @@ static NSMutableDictionary *merge(NSDictionary *into, NSDictionary *with) {
     [ret addEntriesFromDictionary:with];
     
     // 'cascading' styles
-    UIFont* inheritedFont = [into objectForKey:NSFontAttributeName];
+    TARGET_PLATFORM_FONT* inheritedFont = [into objectForKey:NSFontAttributeName];
     if (inheritedFont) {
-        UIFont* elementFont = [with objectForKey:NSFontAttributeName];
+        TARGET_PLATFORM_FONT* elementFont = [with objectForKey:NSFontAttributeName];
         if (elementFont) {
 
             CTFontRef inheritedCTFont =  CTFontCreateWithName((CFStringRef)inheritedFont.fontName, inheritedFont.pointSize, NULL);
@@ -118,7 +118,7 @@ static NSMutableDictionary *merge(NSDictionary *into, NSDictionary *with) {
             
             // make a new UIFont/NSFont
             NSString *newFontName = [(NSString *)CTFontCopyName(outCTFont, kCTFontPostScriptNameKey) autorelease];
-            UIFont* newFont = [UIFont fontWithName:newFontName size:inheritedFont.pointSize];
+            TARGET_PLATFORM_FONT* newFont = [TARGET_PLATFORM_FONT fontWithName:newFontName size:inheritedFont.pointSize];
 
             if (newFont) {
                 [ret setObject:newFont forKey:NSFontAttributeName];
@@ -198,7 +198,7 @@ static void print_attr_element(NSMutableAttributedString *out, element *elt, NSD
                 NSDictionary *linkAttibutes = @{@"attributedMarkdownURL": url};
                 print_attr_element_list(out, elt->contents.link->label, attributes, merge(current, merge(attributes[elt->key], linkAttibutes)));
             } else {
-                NSDictionary *attributesBroken = @{NSForegroundColorAttributeName: [UIColor redColor]}; // Make this attributes[BROKEN]
+                NSDictionary *attributesBroken = @{NSForegroundColorAttributeName: [TARGET_PLATFORM_COLOR redColor]}; // Make this attributes[BROKEN]
                 print_attr_element_list(out, elt->contents.link->label, attributes, merge(current, attributesBroken));
                 print_attr_string(out, [NSString stringWithFormat: @" (%@)", elt->contents.link->url], current);
             }

--- a/platform.h
+++ b/platform.h
@@ -1,0 +1,15 @@
+#import <TargetConditionals.h>
+
+#if TARGET_OS_IPHONE    // iPhone-specific
+
+#import <UIKit/UIKit.h>
+#define TARGET_PLATFORM_COLOR UIColor
+#define TARGET_PLATFORM_FONT UIFont
+
+#else                   // OS X-specific
+
+#import <AppKit/AppKit.h>
+#define TARGET_PLATFORM_COLOR NSColor
+#define TARGET_PLATFORM_FONT NSFont
+
+#endif


### PR DESCRIPTION
Added platform.h that includes OSX-specific and iOS-specific #defines and @imports for properly resolving platform-dependent classes. This header was added to the pch.
