### PR TITLE
Fix Unicode problems

### DIFF
--- a/parsing_functions.m
+++ b/parsing_functions.m
@@ -66,7 +66,7 @@ element * parse_references(NSString *string, int extensions) {
     md.syntax_extensions = extensions;
 
     struct Input saved = md.input;
-    md.input.charbuf  = string;
+    md.input.charbuf  = (char *)[string UTF8String];
     md.input.position = 0;
   
     parse_from(yy_References);           /* first pass, just to collect references */
@@ -84,7 +84,7 @@ element * parse_notes(NSString *string, int extensions, element *reference_list)
         md.references = reference_list;
 
         struct Input saved = md.input;
-        md.input.charbuf  = string;
+        md.input.charbuf  = (char *)[string UTF8String];
         md.input.position = 0;
 
         parse_from(yy_Notes);           /* second pass for notes */
@@ -101,7 +101,7 @@ element * parse_markdown(NSString *string, int extensions, element *reference_li
     md.notes = note_list;
 
     struct Input saved = md.input;
-    md.input.charbuf  = string;
+    md.input.charbuf  = (char *)[string UTF8String];
     md.input.position = 0;
   
     parse_from(yy_Doc);

--- a/utility_functions.m
+++ b/utility_functions.m
@@ -49,7 +49,7 @@ static NSMutableString *concat_string_list(element *list) {
  ***********************************************************************/
 
 struct Input {
-    NSString *charbuf;     /* Buffer of characters to be parsed. */
+    char *charbuf;         /* Buffer of characters to be parsed. */
     NSUInteger position;   /* Curent index into charbuf. */
 };
 
@@ -86,7 +86,7 @@ static element * mk_str(const char *string) {
     element *result;
     assert(string != NULL);
     result = mk_element(STRING);
-    result->contents.str = [[NSMutableString alloc] initWithCString:string encoding:NSASCIIStringEncoding];
+    result->contents.str = [[NSMutableString alloc] initWithCString:string encoding:NSUTF8StringEncoding];
     return result;
 }
 
@@ -207,24 +207,24 @@ static bool find_note(element **result, NSString *label) {
 
   Definitions for leg parser generator.
   YY_INPUT is the function the parser calls to get new input.
-  We take all new input from (static) charbuf.
+  We take all new input from charbuf.
 
  ***********************************************************************/
 
-# define YYSTYPE element *
+#define YYSTYPE element *
 #ifdef __DEBUG__
-# define YY_DEBUG 1
+#define YY_DEBUG 1
 #endif
 
-#define YY_INPUT(buf, result, max_size, data)                         \
-{                                                                     \
-    NSInteger yyc;                                                    \
-    if (md.input.position < md.input.charbuf.length) {                \
-        yyc= [md.input.charbuf characterAtIndex:md.input.position++]; \
-    } else {                                                          \
-        yyc= EOF;                                                     \
-    }                                                                 \
-    result= (EOF == yyc) ? 0 : (*(buf) = yyc, 1);                     \
+#define YY_INPUT(buf, result, max_size, data)             \
+{                                                         \
+    int yyc;                                              \
+    if (md.input.charbuf && *md.input.charbuf != '\0') {  \
+        yyc= *md.input.charbuf++;                         \
+    } else {                                              \
+        yyc= EOF;                                         \
+    }                                                     \
+    result= (EOF == yyc) ? 0 : (*(buf)= yyc, 1);          \
 }
 
 


### PR DESCRIPTION
As per #13, Unicode support is presently poor, and use of non-Latin scripts quickly results in broken output.

The problem is the [use of `characterAtIndex:`](https://github.com/dreamwieber/AttributedMarkdown/blob/2bde0b6f90326ff0bbcd3e184e7e0f6972ff2aa3/utility_functions.m#L223) in the `YY_INPUT` macro. Building a string relying on this doesn't work as this returns a `unichar`, a 16-bit value.

I've changed the internals of the parser to avoid passing around an `NSString`, instead converting to a C string right out of the gate using `UTF8String`. In my testing, this handles any Unicode I can throw at it (including all the broken characters mentioned in the previous issue).
