### PR TITLE
Added requires_arc = false flag for cocoapods 0.34

### DIFF
--- a/AttributedMarkdown.podspec
+++ b/AttributedMarkdown.podspec
@@ -14,4 +14,5 @@ Pod::Spec.new do |s|
   s.preserve_path = "utility_functions.m", "parsing_functions.m"
   s.ios.frameworks = 'CoreText', 'UIKit', 'Foundation'
   s.osx.frameworks = 'CoreText', 'AppKit', 'Foundation'
+  s.requires_arc = false
 end


### PR DESCRIPTION
http://blog.cocoapods.org/CocoaPods-0.34/

The introduction of CocoaPods 0.34 influences podspecs slightly.
The flag "requires_arc" now defaults to true.

Since AttributedMarkdown uses self managed memory it causes arc related compiler errors with the latest version of CocoaPods. This is an easy fix that simply adds the required flag to the podspec.
